### PR TITLE
allow filters to be set to null

### DIFF
--- a/src/models/slices/filters.ts
+++ b/src/models/slices/filters.ts
@@ -1,5 +1,5 @@
 import { CombinedFilter, Filter } from '@yext/answers-core';
 
 export interface FiltersState {
-  static?: Filter | CombinedFilter;
+  static?: Filter | CombinedFilter | null;
 }

--- a/src/slices/filters.ts
+++ b/src/slices/filters.ts
@@ -12,7 +12,7 @@ export const filtersSlice = createSlice({
   name: 'filters',
   initialState,
   reducers: {
-    setStatic: (state: FiltersState, action: PayloadAction<Filter|CombinedFilter>) => {
+    setStatic: (state: FiltersState, action: PayloadAction<Filter|CombinedFilter|null>) => {
       state.static = action.payload;
     },
   }

--- a/src/stateful-core.ts
+++ b/src/stateful-core.ts
@@ -23,7 +23,7 @@ export default class StatefulCore {
     this.stateManager.dispatchEvent('vertical/setKey', key);
   }
 
-  setFilter(filter: Filter | CombinedFilter): void {
+  setFilter(filter: Filter | CombinedFilter | null): void {
     this.stateManager.dispatchEvent('filters/setStatic', filter);
   }
 
@@ -74,7 +74,7 @@ export default class StatefulCore {
       throw new Error('no verticalKey suppled for vertical search');
     }
     const { query, querySource, queryTrigger } = this.state.query;
-    const staticFilters = this.state.filters.static;
+    const staticFilters = this.state.filters.static || undefined;
     if (query) {
       const results = await this.core.verticalSearch({
         query,


### PR DESCRIPTION
Previously, there was no way to unset filters
I slightly prefer setFilter(null) as opposed to a bespoke unsetFilter()

TEST=manual

tested static filters in the react test app