### PR TITLE
return individual answers-core requests from executes()

### DIFF
--- a/src/stateful-core.ts
+++ b/src/stateful-core.ts
@@ -8,7 +8,8 @@ import {
   Facet,
   AutocompleteResponse,
   VerticalSearchResponse,
-  UniversalSearchResponse
+  UniversalSearchResponse,
+  QuestionSubmissionResponse
 } from '@yext/answers-core';
 
 import StateListener from './models/state-listener';
@@ -54,8 +55,8 @@ export default class StatefulCore {
     return this.stateManager.addListener<T>(listener);
   }
 
-  async submitQuestion(request: QuestionSubmissionRequest): Promise<void> {
-    await this.core.submitQuestion(request);
+  async submitQuestion(request: QuestionSubmissionRequest): Promise<QuestionSubmissionResponse> {
+    return this.core.submitQuestion(request);
   }
 
   async executeUniversalQuery(): Promise<UniversalSearchResponse | undefined> {


### PR DESCRIPTION
For the Autocomplete component, it's important that one
SearchBar's Autocomplete does not cause another SearchBar's
autocomplete to start displaying results. Unfortunately, this
is what happens when component's listen to a shared autocomplete
state.

Returning the request itself, in addition to dispatching an action,
lets components decide whether they would like to engage in a "push"
or "pull" relationship with answers-headless.
These return values can act as a "pressure release valve", for users that
want to manage some piece of state themselves, without really adding
any complexity at all to answers-headless.

Also tweak the "no vertical key" error to only do a console log, since it
was pretty disruptive to development, and also fix a typo.

TEST=manual

used this in the react sample app