### PR TITLE
allow blank autocomplete queries

### DIFF
--- a/src/stateful-core.ts
+++ b/src/stateful-core.ts
@@ -74,15 +74,14 @@ export default class StatefulCore {
     }
   }
 
-  async executeUniversalAutoComplete(query = this.state.query.query): Promise<AutocompleteResponse | undefined> {
-    if (query) {
-      const results = await this.core.universalAutocomplete({
-        input: query
-      });
+  async executeUniversalAutoComplete(query?: string): Promise<AutocompleteResponse | undefined> {
+    query = query || this.state.query.query || '';
+    const results = await this.core.universalAutocomplete({
+      input: query
+    });
 
-      this.stateManager.dispatchEvent('universal/setAutoComplete', results);
-      return results;
-    }
+    this.stateManager.dispatchEvent('universal/setAutoComplete', results);
+    return results;
   }
 
   async executeVerticalQuery(): Promise<VerticalSearchResponse | undefined> {
@@ -111,22 +110,21 @@ export default class StatefulCore {
     }
   }
 
-  async executeVerticalAutoComplete(query = this.state.query.query): Promise<AutocompleteResponse | undefined> {
+  async executeVerticalAutoComplete(query?: string): Promise<AutocompleteResponse | undefined> {
+    query = query || this.state.query.query || '';
     const verticalKey = this.state.vertical.key;
     if (!verticalKey) {
       console.error('no verticalKey supplied for vertical autocomplete');
       return;
     }
 
-    if (query) {
-      const results = await this.core.verticalAutocomplete({
-        input: query,
-        verticalKey: verticalKey
-      });
+    const results = await this.core.verticalAutocomplete({
+      input: query,
+      verticalKey: verticalKey
+    });
 
-      this.stateManager.dispatchEvent('vertical/setAutoComplete', results);
-      return results;
-    }
+    this.stateManager.dispatchEvent('vertical/setAutoComplete', results);
+    return results;
   }
 }
 


### PR DESCRIPTION
This commit lets users submit blank string autocomplete queries. This is something the SDK is currently
able to do, you can see this by going to answers.yext.com and clicking on the searchbar with no
query typed in yet. I thought I was going insane when my component wouldn't delete its autocomplete
dropdown after I deleted the query.

J=SLAP-1428
TEST=manual

use this with the searchbar component