### PR TITLE
Only send selected facets in the vertical search request

### DIFF
--- a/src/stateful-core.ts
+++ b/src/stateful-core.ts
@@ -118,12 +118,12 @@ export default class StatefulCore {
     const limit = this.state.vertical.limit;
     const offset = this.state.vertical.offset;
 
-    const selectedFacets = facets?.map(facet => {
+    const facetsToApply = facets?.map(facet => {
       return {
         fieldId: facet.fieldId,
         options: facet.options.filter(o => o.selected)
       };
-    }).filter(facet => facet.options.length > 0 );
+    });
 
     if (query) {
       const request = {
@@ -132,7 +132,7 @@ export default class StatefulCore {
         queryTrigger: queryTrigger,
         verticalKey: verticalKey,
         staticFilters,
-        facets: selectedFacets,
+        facets: facetsToApply,
         retrieveFacets: true,
         limit: limit,
         offset: offset,

--- a/tests/integration/facets.ts
+++ b/tests/integration/facets.ts
@@ -152,6 +152,10 @@ it('only selected facets are sent in the vertical search request', () => {
     {
       fieldId: 'testFieldId2',
       options: [selectedFacetOption, selectedFacetOption]
+    },
+    {
+      fieldId: 'testFieldId3',
+      options: []
     }]
   }));
 });


### PR DESCRIPTION
Add a filter to only send the facets which are selected

In Answers Core, `DisplayableFacetOption` has a selected property, but `FacetOption` does not. We weren't taking this into account, so every `DisplayableFacetOption` we were supplying to Answers Core was being considered a selected `Facet`.

J=SLAP-1554
TEST=auto

Add an integration test which confirms that only selected facets are sent to the api