### PR TITLE
set initial previousValue state of every listener correctly

### DIFF
--- a/src/redux-state-manager.ts
+++ b/src/redux-state-manager.ts
@@ -47,7 +47,7 @@ export default class ReduxStateManager implements StateManager {
   }
 
   addListener<T>(listener: StateListener<T>): Unsubscribe {
-    let previousValue: T;
+    let previousValue = listener.valueAccessor(this.getState());
     return this.store.subscribe(() => {
       const currentValue: T = listener.valueAccessor(this.getState());
       if (currentValue !== previousValue) {


### PR DESCRIPTION
previously, these would be set to undefined.
This would result the next redux action for state.stateBeingListenedTo
to always result in the listener triggering, even if the state had not
actually changed.
Also, react components remove their old listener and register a new one
every render. Because previousValue is stored as a fixture inside the listener,
previousValue would be wiped out to undefined every single render, meaning
previously every single render would be doubled.