### PR TITLE
Add commonjs build

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
   ],
   ignorePatterns: [
     'lib',
-    'scripts'
+    'scripts',
+    'test-site-node'
   ],
 };

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "",
   "author": "slapshot@yext.com",
   "license": "ISC",
-  "main": "./lib/esm/index.js",
+  "main": "./lib/commonjs/index.js",
   "module": "./lib/esm/index.js",
   "files": [
     "lib"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
     "test": "jest",
@@ -60,7 +60,8 @@
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/tests/mocks/*",
-      "<rootDir>/tests/utils/*"
+      "<rootDir>/tests/utils/*",
+      "<rootDir>/test-site-node/*"
     ]
   }
 }

--- a/test-site-node/index.js
+++ b/test-site-node/index.js
@@ -1,0 +1,15 @@
+const { provideAnswersHeadless } = require('@yext/answers-headless');
+
+const answers = provideAnswersHeadless({
+  apiKey: '2d8c550071a64ea23e263118a2b0680b',
+  experienceKey: 'slanswers',
+  locale: 'en'
+});
+
+const test = async () => {
+  answers.setQuery('virginia');
+  await answers.executeUniversalQuery();
+  console.log(answers.state);
+}
+
+test();

--- a/test-site-node/package-lock.json
+++ b/test-site-node/package-lock.json
@@ -1,0 +1,71 @@
+{
+  "name": "test-site-node",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "test-site-node",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@yext/answers-headless": "file:.."
+      }
+    },
+    "..": {
+      "version": "0.1.0-beta.0",
+      "license": "ISC",
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.6.0",
+        "@yext/answers-core": "^1.3.2",
+        "js-levenshtein": "^1.1.6",
+        "redux-thunk": "^2.3.0"
+      },
+      "devDependencies": {
+        "@babel/preset-env": "^7.14.7",
+        "@babel/preset-typescript": "^7.14.5",
+        "@types/jest": "^26.0.24",
+        "@types/lodash": "^4.14.175",
+        "@types/node": "^14.14.28",
+        "@typescript-eslint/eslint-plugin": "^4.28.2",
+        "@typescript-eslint/parser": "^4.28.2",
+        "babel-jest": "^27.0.6",
+        "eslint": "^7.30.0",
+        "generate-license-file": "^1.2.0",
+        "jest": "^27.0.6",
+        "lodash": "^4.17.21",
+        "ts-node": "^9.1.1",
+        "typescript": "^4.1.5"
+      }
+    },
+    "node_modules/@yext/answers-headless": {
+      "resolved": "..",
+      "link": true
+    }
+  },
+  "dependencies": {
+    "@yext/answers-headless": {
+      "version": "file:..",
+      "requires": {
+        "@babel/preset-env": "^7.14.7",
+        "@babel/preset-typescript": "^7.14.5",
+        "@reduxjs/toolkit": "^1.6.0",
+        "@types/jest": "^26.0.24",
+        "@types/lodash": "^4.14.175",
+        "@types/node": "^14.14.28",
+        "@typescript-eslint/eslint-plugin": "^4.28.2",
+        "@typescript-eslint/parser": "^4.28.2",
+        "@yext/answers-core": "^1.3.2",
+        "babel-jest": "^27.0.6",
+        "eslint": "^7.30.0",
+        "generate-license-file": "^1.2.0",
+        "jest": "^27.0.6",
+        "js-levenshtein": "^1.1.6",
+        "lodash": "^4.17.21",
+        "redux-thunk": "^2.3.0",
+        "ts-node": "^9.1.1",
+        "typescript": "^4.1.5"
+      }
+    }
+  }
+}

--- a/test-site-node/package.json
+++ b/test-site-node/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "test-site-node",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@yext/answers-headless": "file:.."
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,9 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
     "strict": true,
-    "module": "es6",
-    "outDir": "lib/esm",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "noImplicitAny": false,

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "outDir": "lib/commonjs"
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "es6",
+    "outDir": "lib/esm"
+  }
+}


### PR DESCRIPTION
Add a commonjs build of the library so that we can support node 

I also bumped the javascript version to es2017 because it is widely supported and contains many javascript features that we commonly use which results in smaller builds because less syntax transformations are needed by the typescript compiler. Compatibility table: http://kangax.github.io/compat-table/es2016plus/

J=SLAP-1642
TEST=manual

Add a test-site-node and confirm that headless works in node