### PR TITLE
Fixed types of exports

### DIFF
--- a/docs/search-headless.answersheadless.md
+++ b/docs/search-headless.answersheadless.md
@@ -2,7 +2,7 @@
 
 [Home](./index.md) &gt; [@yext/search-headless](./search-headless.md) &gt; [AnswersHeadless](./search-headless.answersheadless.md)
 
-## AnswersHeadless variable
+## AnswersHeadless class
 
 > Warning: This API is now obsolete.
 > 
@@ -12,5 +12,7 @@
 <b>Signature:</b>
 
 ```typescript
-AnswersHeadless: typeof SearchHeadless
+export declare class AnswersHeadless extends SearchHeadless 
 ```
+<b>Extends:</b> SearchHeadless
+

--- a/docs/search-headless.answersutilities.md
+++ b/docs/search-headless.answersutilities.md
@@ -2,7 +2,7 @@
 
 [Home](./index.md) &gt; [@yext/search-headless](./search-headless.md) &gt; [answersUtilities](./search-headless.answersutilities.md)
 
-## answersUtilities variable
+## answersUtilities namespace
 
 > Warning: This API is now obsolete.
 > 
@@ -12,5 +12,5 @@
 <b>Signature:</b>
 
 ```typescript
-answersUtilities: typeof searchUtilities
+export declare namespace answersUtilities 
 ```

--- a/docs/search-headless.md
+++ b/docs/search-headless.md
@@ -9,6 +9,7 @@
 |  Class | Description |
 |  --- | --- |
 |  [AnswersCore](./search-headless.answerscore.md) |  |
+|  [AnswersHeadless](./search-headless.answersheadless.md) |  |
 |  [SearchCore](./search-headless.searchcore.md) | Provides methods for executing searches, submitting questions, and performing autocompletes. |
 |  [SearchError](./search-headless.searcherror.md) | Represents an error |
 |  [SearchHeadless](./search-headless.searchheadless.md) | Provides the functionality for interacting with a Search experience. |
@@ -133,7 +134,6 @@
 
 |  Variable | Description |
 |  --- | --- |
-|  [AnswersHeadless](./search-headless.answersheadless.md) |  |
 |  [answersUtilities](./search-headless.answersutilities.md) |  |
 |  [DEFAULT\_HEADLESS\_ID](./search-headless.default_headless_id.md) | The headlessId automatically given to the first SearchHeadless instance created. |
 |  [provideAnswersHeadless](./search-headless.provideanswersheadless.md) | Supplies a new instance of [SearchHeadless](./search-headless.searchheadless.md)<!-- -->, using the provided configuration. |

--- a/docs/search-headless.md
+++ b/docs/search-headless.md
@@ -128,13 +128,13 @@
 
 |  Namespace | Description |
 |  --- | --- |
+|  [answersUtilities](./search-headless.answersutilities.md) |  |
 |  [searchUtilities](./search-headless.searchutilities.md) |  |
 
 ## Variables
 
 |  Variable | Description |
 |  --- | --- |
-|  [answersUtilities](./search-headless.answersutilities.md) |  |
 |  [DEFAULT\_HEADLESS\_ID](./search-headless.default_headless_id.md) | The headlessId automatically given to the first SearchHeadless instance created. |
 |  [provideAnswersHeadless](./search-headless.provideanswersheadless.md) | Supplies a new instance of [SearchHeadless](./search-headless.searchheadless.md)<!-- -->, using the provided configuration. |
 |  [SandboxEndpoints](./search-headless.sandboxendpoints.md) | The endpoints to use for sandbox experiences. |

--- a/etc/search-headless.api.md
+++ b/etc/search-headless.api.md
@@ -46,7 +46,7 @@ export interface AnswersRequest extends SearchRequest {
 }
 
 // @public @deprecated (undocumented)
-export const answersUtilities: typeof searchUtilities;
+export namespace answersUtilities { }
 
 // @public
 export interface AppliedQueryFilter {

--- a/etc/search-headless.api.md
+++ b/etc/search-headless.api.md
@@ -38,7 +38,8 @@ export interface AnswersError extends SearchError {
 }
 
 // @public @deprecated (undocumented)
-export const AnswersHeadless: typeof SearchHeadless;
+export class AnswersHeadless extends SearchHeadless {
+}
 
 // @public @deprecated (undocumented)
 export interface AnswersRequest extends SearchRequest {

--- a/src/deprecated.ts
+++ b/src/deprecated.ts
@@ -36,4 +36,4 @@ export const provideAnswersHeadless = provideHeadless;
  *
  * @deprecated AnswersHeadless has been deprecated and renamed to SearchHeadless
  */
-export const AnswersHeadless = SearchHeadless;
+export class AnswersHeadless extends SearchHeadless {}

--- a/src/deprecated.ts
+++ b/src/deprecated.ts
@@ -16,7 +16,8 @@ export {
  *
  * @deprecated answersUtilities has been deprecated and renamed to searchUtilities
  */
-export namespace answersUtilities { searchUtilities };
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace answersUtilities { searchUtilities; }
 
 /**
  * Supplies a new instance of {@link SearchHeadless}, using the provided configuration.

--- a/src/deprecated.ts
+++ b/src/deprecated.ts
@@ -16,7 +16,7 @@ export {
  *
  * @deprecated answersUtilities has been deprecated and renamed to searchUtilities
  */
-export const answersUtilities = searchUtilities;
+export namespace answersUtilities { searchUtilities };
 
 /**
  * Supplies a new instance of {@link SearchHeadless}, using the provided configuration.


### PR DESCRIPTION
Fix for release v1.3.0, fixed the class export for deprecated `AnswersHeadless` and the namespace export for `answersUtilities`

*because we haven't released v1.3.0 yet, we don't need a hotfix version bump