### PR TITLE
bump version after removing deprecate code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^2.0.0-alpha.218",
+        "@yext/search-core": "2.0.0-alpha.218",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-headless",
-  "version": "2.0.0-alpha.133",
+  "version": "2.0.0-alpha.134",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-headless",
-      "version": "2.0.0-alpha.133",
+      "version": "2.0.0-alpha.134",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.8.1",
-    "@yext/search-core": "^2.0.0-alpha.218",
+    "@yext/search-core": "2.0.0-alpha.218",
     "js-levenshtein": "^1.1.6",
     "lodash": "^4.17.21"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-headless",
-  "version": "2.0.0-alpha.133",
+  "version": "2.0.0-alpha.134",
   "description": "A library for powering UI components for Yext Search integrations",
   "author": "slapshot@yext.com",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
This PR bumps the version to `2.0.0-alpha.134` after the deletion of all deprecated code.

TEST=auto