### PR TITLE
Reuse queryId for pagination

### DIFF
--- a/src/search-headless.ts
+++ b/src/search-headless.ts
@@ -411,6 +411,9 @@ export default class SearchHeadless {
     const { limit, offset, sortBys, locationRadius } = this.state.vertical;
     const { referrerPageUrl, context } = this.state.meta;
     const { userLocation } = this.state.location;
+    const zeroOffset = this.state.vertical.offset ?? 0;
+    const inputIsPreviousQuery = input == this.state.query.mostRecentSearch;
+    const queryId = !zeroOffset || inputIsPreviousQuery ? this.state.query.queryId : undefined;
 
     const facetsToApply = facets?.map(facet => {
       return {
@@ -437,7 +440,8 @@ export default class SearchHeadless {
       context,
       referrerPageUrl,
       locationRadius,
-      additionalHttpHeaders: this.additionalHttpHeaders
+      additionalHttpHeaders: this.additionalHttpHeaders,
+      queryId
     };
 
     let response: VerticalSearchResponse;

--- a/src/search-headless.ts
+++ b/src/search-headless.ts
@@ -402,7 +402,7 @@ export default class SearchHeadless {
       return;
     }
     this.stateManager.dispatchEvent('searchStatus/setIsLoading', true);
-    const { input, querySource, queryTrigger } = this.state.query;
+    const { input, querySource, queryTrigger, mostRecentSearch, queryId } = this.state.query;
     const skipSpellCheck = !this.state.spellCheck.enabled;
     const sessionTrackingEnabled = this.state.sessionTracking.enabled;
     const sessionId = this.state.sessionTracking.sessionId;
@@ -411,9 +411,9 @@ export default class SearchHeadless {
     const { limit, offset, sortBys, locationRadius } = this.state.vertical;
     const { referrerPageUrl, context } = this.state.meta;
     const { userLocation } = this.state.location;
-    const zeroOffset = this.state.vertical.offset ?? 0;
-    const inputIsPreviousQuery = input == this.state.query.mostRecentSearch;
-    const queryId = !zeroOffset || inputIsPreviousQuery ? this.state.query.queryId : undefined;
+    const zeroOffset = offset == 0 || offset == undefined;
+    const inputIsPreviousQuery = input == mostRecentSearch;
+    const nextQueryId = (!zeroOffset || inputIsPreviousQuery) ? queryId : undefined;
 
     const facetsToApply = facets?.map(facet => {
       return {
@@ -440,8 +440,8 @@ export default class SearchHeadless {
       context,
       referrerPageUrl,
       locationRadius,
-      additionalHttpHeaders: this.additionalHttpHeaders,
-      queryId
+      queryId: nextQueryId,
+      additionalHttpHeaders: this.additionalHttpHeaders
     };
 
     let response: VerticalSearchResponse;

--- a/tests/integration/verticalsearch.ts
+++ b/tests/integration/verticalsearch.ts
@@ -169,6 +169,24 @@ it('answers.setVerticalLimit sets the vertical limit when a number is passed to 
   expect(answers.state.vertical.limit).toEqual(7);
 });
 
+it('vertical searches re-use queryId when offset is non-0', async () => {
+  const answers = createMockedHeadless();
+  await answers.executeVerticalQuery();
+  const firstQueryId = answers.state.query.queryId;
+  answers.setOffset(5);
+  answers.setQuery('different query');
+  await answers.executeVerticalQuery();
+  expect(answers.state.query.queryId).toEqual(firstQueryId);
+});
+
+it('vertical searches re-use queryId when query is the same', async () => {
+  const answers = createMockedHeadless();
+  await answers.executeVerticalQuery();
+  const firstQueryId = answers.state.query.queryId;
+  await answers.executeVerticalQuery();
+  expect(answers.state.query.queryId).toEqual(firstQueryId);
+});
+
 it('handle a rejected promise from core', async () => {
   const mockSearch = createMockRejectedSearch();
   const mockCore = { verticalSearch: mockSearch };

--- a/tests/integration/verticalsearch.ts
+++ b/tests/integration/verticalsearch.ts
@@ -170,7 +170,7 @@ it('answers.setVerticalLimit sets the vertical limit when a number is passed to 
 });
 
 it('vertical searches re-use queryId when offset is non-0', async () => {
-  const answers = createMockedHeadless();
+  const answers = createMockedHeadless( { verticalSearch: createMockSearch() }, initialState);
   await answers.executeVerticalQuery();
   const firstQueryId = answers.state.query.queryId;
   answers.setOffset(5);
@@ -180,11 +180,20 @@ it('vertical searches re-use queryId when offset is non-0', async () => {
 });
 
 it('vertical searches re-use queryId when query is the same', async () => {
-  const answers = createMockedHeadless();
+  const answers = createMockedHeadless( { verticalSearch: createMockSearch() }, initialState);
   await answers.executeVerticalQuery();
   const firstQueryId = answers.state.query.queryId;
   await answers.executeVerticalQuery();
   expect(answers.state.query.queryId).toEqual(firstQueryId);
+});
+
+it('vertical searches change queryId when query is different and offset is zero', async () => {
+  const answers = createMockedHeadless( { verticalSearch: createMockSearch() }, initialState);
+  await answers.executeVerticalQuery();
+  const firstQueryId = answers.state.query.queryId;
+  answers.setQuery('different query');
+  await answers.executeVerticalQuery();
+  expect(answers.state.query.queryId).not.toEqual(firstQueryId);
 });
 
 it('handle a rejected promise from core', async () => {
@@ -217,7 +226,11 @@ it('executeVerticalQuery passes the additional HTTP headers', async () => {
 function createMockSearch() {
   return jest.fn(async (_request: VerticalSearchRequest) => {
     await setTimeout(0);
-    return Promise.resolve({});
+    return Promise.resolve({
+      // preserves queryId if passed-in, else generates a random string
+      queryId: _request.queryId == undefined ?
+        (Math.random()).toString(36).substring(2) : _request.queryId
+    });
   });
 }
 


### PR DESCRIPTION
This change adjusts our vertical querying logic to re-use the same queryId when the offset is non-zero or the previous query matches the current input, as both are indications that pagination is being used.
J=WAT-4105
TEST=auto

wrote new tests