### PR TITLE
set default sessionTrackingEnabled to true

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-headless",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-headless",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-headless",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "A library for powering UI components for Yext Search integrations",
   "author": "slapshot@yext.com",
   "license": "BSD-3-Clause",

--- a/src/slices/sessiontracking.ts
+++ b/src/slices/sessiontracking.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction, Slice } from '@reduxjs/toolkit';
 import { SessionTrackingState } from '../models/slices/sessiontracking';
 
 const initialState: SessionTrackingState = {
-  enabled: false
+  enabled: true
 };
 
 const reducers = {

--- a/tests/acceptance/multiple-instances.ts
+++ b/tests/acceptance/multiple-instances.ts
@@ -33,7 +33,7 @@ it('multiple SearchHeadless instances link SessionTrackingState together', () =>
   const expectedIntermediaryState = {
     ...updatedState,
     sessionTracking: {
-      enabled: false,
+      enabled: true,
       sessionId: '123'
     }
   };
@@ -41,11 +41,11 @@ it('multiple SearchHeadless instances link SessionTrackingState together', () =>
   expect(secondHeadless.state).toEqual(expectedIntermediaryState);
   expect(thirdHeadless.state).toEqual(expectedIntermediaryState);
 
-  secondHeadless.setSessionTrackingEnabled(true);
+  secondHeadless.setSessionTrackingEnabled(false);
   const expectedFinalState = {
     ...updatedState,
     sessionTracking: {
-      enabled: true,
+      enabled: false,
       sessionId: '123'
     }
   };

--- a/tests/integration/query.ts
+++ b/tests/integration/query.ts
@@ -80,7 +80,7 @@ describe('sessionId to request works as expected', () => {
 });
 
 describe('ensure correct results from latest request', () => {
-  jest.useFakeTimers();
+  jest.useFakeTimers({ legacyFakeTimers: true });
   const queries = ['really long request', 'short', 'long request'];
   const requestsTime = {
     [queries[0]]: 20,

--- a/tests/integration/redux-state-manager.ts
+++ b/tests/integration/redux-state-manager.ts
@@ -118,7 +118,7 @@ it('addListener can be used to link together different headless instances', () =
   const expectedStartState = {
     ...expectedInitialState,
     sessionTracking: {
-      enabled: false
+      enabled: true
     }
   };
   expect(store.getState()).toEqual({
@@ -129,10 +129,10 @@ it('addListener can be used to link together different headless instances', () =
   const expectedFinalState = {
     ...expectedInitialState,
     sessionTracking: {
-      enabled: true
+      enabled: false
     }
   };
-  firstHeadless.setSessionTrackingEnabled(true);
+  firstHeadless.setSessionTrackingEnabled(false);
   expect(store.getState()).toEqual({
     first: expectedFinalState,
     second: expectedFinalState

--- a/tests/mocks/expectedInitialState.ts
+++ b/tests/mocks/expectedInitialState.ts
@@ -9,7 +9,7 @@ export const expectedInitialState: State = {
   },
   query: {},
   sessionTracking: {
-    enabled: false
+    enabled: true
   },
   spellCheck: {
     enabled: true

--- a/tests/unit/slices/sessiontracking.ts
+++ b/tests/unit/slices/sessiontracking.ts
@@ -23,3 +23,11 @@ describe('sessionTracking slice reducer works as expected', () => {
     expect(actualState).toEqual(expectedState);
   });
 });
+
+describe('sessionTracking is enabled by default', () => {
+  it('initial state is enabled', () => {
+    const initialState = reducer(undefined, { type: '' });
+    expect(initialState.enabled).toBe(true);
+  }
+  );
+});


### PR DESCRIPTION
Previously this was set to `false` by default. However, the theme and Hitchhiker docs indicate that we want this to be enabled by default, so I have done so here.

J=[WAT-4883](https://yexttest.atlassian.net/browse/WAT-4883?atlOrigin=eyJpIjoiMWMzZjU3YWRhOTE0NDdiYmI0OWI3N2Y2ZTA4ODNkZmUiLCJwIjoiaiJ9)
TEST=auto
updated tests